### PR TITLE
Home page header links

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -71,18 +71,59 @@ hr.hr-5 {
     margin-top: 2.5%;
 }
 .collection-head-links {
+    position: relative;
     margin: auto;
     color: #fff;
     font-weight: 700;
-    overflow: hidden;
-    transition: ease .8s;
-}
-.collection-head-links:hover {
-    text-decoration: underline double #fc3355 1px;
+    /* overflow: hidden; */
+    /* transition: ease .8s; */
 }
 .header-space {
     color: #fc3355;
 }
+
+/* hover links */
+.collection-head-links:after {
+    content: "";
+    position: absolute;
+    top: 20px;
+    left: 0;
+    height: 2px;
+    transform: scaleX(0);
+    background: #fc3355;
+    transform-origin: bottom left;
+    transition: transform 0.45s ease-out;
+}
+.collection-head-links:hover:after {
+    transform: scaleX(1);
+    transform-origin: bottom left;
+}
+
+.beach-link:after {
+    width: 55px;
+}
+.clouds-link:after {
+    width: 60px;
+}
+.food-link:after {
+    width: 45px;
+}
+.nature-link:after {
+    width: 60px;
+}
+.night-link:after {
+    width: 90px;
+}
+.street-link:after {
+    width: 55px;
+}
+.sunrise-link:after {
+    width: 70px;
+}
+.sunset-link:after {
+    width: 65px;
+}
+
 
 /* for the pages with a double display where the left side is fixed */
 

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -10,21 +10,21 @@
             </div>
 
             <div class="header-links">
-                <a class="collection-head-links" href="/beach">Beach</a>
+                <a class="collection-head-links beach-link" href="/beach">Beach</a>
                 <span class="header-space">•</span>
-                <a class="collection-head-links" href="/clouds">Clouds</a>
+                <a class="collection-head-links clouds-link" href="/clouds">Clouds</a>
                 <span class="header-space">•</span>
-                <a class="collection-head-links" href="/food">Food</a>
+                <a class="collection-head-links food-link" href="/food">Food</a>
                 <span class="header-space">•</span>
-                <a class="collection-head-links" href="/nature">Nature</a>
+                <a class="collection-head-links nature-link" href="/nature">Nature</a>
                 <span class="header-space">•</span>
-                <a class="collection-head-links" href="/night">Night Time</a>
+                <a class="collection-head-links night-link" href="/night">Night Time</a>
                 <span class="header-space">•</span>
-                <a class="collection-head-links" href="/street">Street</a>
+                <a class="collection-head-links street-link" href="/street">Street</a>
                 <span class="header-space">•</span>
-                <a class="collection-head-links" href="/sunrise">Sunrises</a>
+                <a class="collection-head-links sunrise-link" href="/sunrise">Sunrises</a>
                 <span class="header-space">•</span>
-                <a class="collection-head-links" href="/sunset">Sunsets</a>
+                <a class="collection-head-links sunset-link" href="/sunset">Sunsets</a>
             </div>
 
         </div>


### PR DESCRIPTION
On the home page, I gave the links to the collections in the header a underline animation when hovered over.

In order to do this, I followed the same method as when I gave the titles in the cards a underline animation by giving them an :after pseudo element and thereafter used a transition.
In order to adjust the underline for the width of each link (due to the number of characters each of them have), I had to give each link pseudo element a class name to target them more specifically.