### PR TITLE
Changed .insta border color

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -880,7 +880,7 @@ ul .about-li {
     border: #4471ca solid 2px;
 }
 .insta:hover {
-    border: 2px solid #fff;
+    border: 2px solid #975097;
     box-sizing: border-box;
     background-image: linear-gradient(to top left, #f58529, #feda77, #dd2a7b, #8134af, #515bd4);
 }


### PR DESCRIPTION
Gave the border of the anchor tag with the class of `.insta` the same color as the background color of the `.about-page` as a work around to the problem of not being able to find a way to get the border to being able to remove without disrupting the flow of the document.