### PR TITLE
Responsiveness

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -67,7 +67,7 @@ hr.hr-5 {
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;
-    width: 50%;
+    width: 100%;
     margin-top: 2.5%;
 }
 .collection-head-links {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -801,7 +801,7 @@ ul .about-li {
 .about-socials {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: space-evenly;
     width: 100%;
     height: 15%;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -826,7 +826,7 @@ ul .about-li {
 }
 .fa-instagram {
     padding: 2px;
-    border-radius: 5px;
+    border-radius: 7px;
     font-size: xx-large;
     background-image: linear-gradient(to top left, #f58529, #feda77, #dd2a7b, #8134af, #515bd4);
 }

--- a/public/css/media.css
+++ b/public/css/media.css
@@ -20,6 +20,7 @@
 }
 
 @media screen and (max-width: 992px) {
+
   /* Navbar */
 
   /* sidebar */
@@ -29,7 +30,7 @@
 
   /* home head */
   .header-links {
-    width: 80%;
+    width: 100%;
   }
 
   /* main home page */
@@ -47,23 +48,67 @@
   .main-left-card {
     width: 45vw;
     margin-right: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .main-right-card {
     width: 45vw;
     margin-left: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .card-title {
     font-size: 3rem;
   }
 
+  /* card hovers */
+  .card-title::after {
+    top: 50px;
+    height: 5px;
+  }
+
+  .beach:after {
+    width: 170px;
+  }
+
+  .clouds:after {
+    width: 205px;
+  }
+
+  .food:after {
+    width: 145px;
+  }
+
+  .nature:after {
+    width: 200px;
+  }
+
+  .night:after {
+    width: 285px;
+  }
+
+  .street:after {
+    width: 190px;
+  }
+
+  .sunrise:after {
+    width: 245px;
+  }
+
+  .sunset:after {
+    width: 225px;
+  }
+
+
   /* BLOGS */
   .blog-card {
     width: 30vw;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
+  }
+
+  .blog-link-btn {
+    width: 20%;
+    font-size: 1.25rem;
   }
 
   /* FOOTER */
@@ -81,6 +126,7 @@
   }
 
   /* ABOUT */
+
 
 
   /* CONTACT */
@@ -163,81 +209,28 @@
   }
 
   /* main home page */
-  .more-btn {
-    width: 40%;
-    border-radius: 2.5rem;
-    font-size: 1.25rem;
-  }
 
-  .more-btn:hover {
-    width: 50%;
-  }
 
   /* cards */
   .main-left-card {
     width: 66vw;
-    margin-right: 0%;
-    margin-bottom: 5%;
   }
 
   .main-right-card {
     width: 66vw;
-    margin-left: 0%;
-    margin-bottom: 5%;
   }
 
-  .card-title {
-    font-size: 3rem;
-  }
 
-    /* card hovers */
-    .card-title::after {
-      top: 50px;
-      height: 5px;
-    }
 
-    .beach:after {
-      width: 170px;
-    }
-  
-    .clouds:after {
-      width: 205px;
-    }
-  
-    .food:after {
-      width: 145px;
-    }
-  
-    .nature:after {
-      width: 200px;
-    }
-  
-    .night:after {
-      width: 285px;
-    }
-  
-    .street:after {
-      width: 190px;
-    }
-  
-    .sunrise:after {
-      width: 245px;
-    }
-  
-    .sunset:after {
-      width: 225px;
-    }
+
 
   /* BLOGS */
   .blog-card {
     width: 66vw;
-    margin-bottom: 5%;
   }
 
-  .blog-link-btn {
-    width: 20%;
-    font-size: 1.25rem;
-  }
+
+
 
   /* ABOUT */
   .about-display {
@@ -460,7 +453,6 @@
 
   .blog-link-btn {
     margin-top: 5%;
-    width: 20%;
     height: 40px;
     font-size: 1rem;
   }

--- a/public/css/media.css
+++ b/public/css/media.css
@@ -431,49 +431,29 @@
 
 @media screen and (max-width: 576px) {
 
+  /* texts */
+  .main-h1 {
+    margin-top: 10%;
+  }
+
   /* Navbar */
   .navbar-brand {
     font-size: x-large;
   }
 
-  /* FOOTER */
-  footer {
-    height: 25%;
-  }
 
-  .footer-social {
-    margin-bottom: 2.5%;
-    margin: auto;
-  }
-
-  .footer-section {
-    width: 100%;
-  }
 
   /* HOME */
 
   /* home head */
   .header-texts h1 {
     font-size: 70%;
+    margin-top: 35%;
   }
 
   .header-links {
-    flex-wrap: wrap;
-    justify-content: center;
     width: 100%;
     margin-top: 2.5%;
-  }
-
-  .collection-head-links:nth-of-type(even) {
-    display: none;
-  }
-
-  .header-space:nth-of-type(even) {
-    display: none;
-  }
-
-  .header-space:nth-of-type(7) {
-    display: none;
   }
 
   /* main home page */
@@ -491,13 +471,13 @@
   .main-left-card {
     width: 75vw;
     margin-right: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .main-right-card {
     width: 75vw;
     margin-left: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .card-title {
@@ -505,8 +485,87 @@
   }
 
   .card-description {
-    margin-bottom: 5%;
+    font-size: medium;
   }
+
+  /* card hovers */
+  .card-title::after {
+    top: 35px;
+    height: 3px;
+  }
+
+  .beach:after {
+    width: 110px;
+  }
+
+  .clouds:after {
+    width: 135px;
+  }
+
+  .food:after {
+    width: 95px;
+  }
+
+  .nature:after {
+    width: 135px;
+  }
+
+  .night:after {
+    width: 190px;
+  }
+
+  .street:after {
+    width: 125px;
+  }
+
+  .sunrise:after {
+    width: 165px;
+  }
+
+  .sunset:after {
+    width: 150px;
+  }
+
+
+    /* GALLERY */
+    .container {
+      grid-template-areas:
+        "top top"
+        "middle middle"
+        "bottom bottom";
+    }
+  
+    .collection1 {
+      grid-area: top;
+      grid-auto-rows: minmax(150px, auto);
+      grid-template-areas:
+        "top-left top-right"
+        "across across";
+      gap: 2px;
+    }
+  
+    .collection2 {
+      grid-area: middle;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-auto-rows: minmax(150px, auto);
+  
+      grid-template-areas:
+        "across across"
+        "bottom-left bottom-right";
+      gap: 2px;
+    }
+  
+    .collection3 {
+      grid-area: bottom;
+      grid-auto-rows: minmax(100px, auto);
+      grid-template-columns: 1fr 1fr;
+      gap: 2px;
+    }
+  
+    .collection3 img:nth-of-type(2) {
+      display: none;
+    }
 
   /* BLOGS */
   .blog-card {
@@ -515,8 +574,10 @@
   }
 
   .blog-link-btn {
+    margin-top: 5%;
     width: 20%;
-    font-size: 1.25rem;
+    height: 40px;
+    font-size: 1rem;
   }
 
   /* CONTACT */
@@ -528,6 +589,20 @@
   }
 
   .contact-form {
+    width: 100%;
+  }
+
+  /* FOOTER */
+  footer {
+    height: 25%;
+  }
+
+  .footer-social {
+    margin-bottom: 2.5%;
+    margin: auto;
+  }
+
+  .footer-section {
     width: 100%;
   }
 
@@ -571,9 +646,7 @@
 @media screen and (max-width: 414px) {
 
   /* texts */
-  .main-h1 {
-    margin-top: 10%;
-  }
+
 
   /* Navbar */
   .navbar-brand {
@@ -583,50 +656,17 @@
   /* HOME */
 
   /* home head */
-  .header-texts h1 {
-    font-size: 70%;
-    margin-top: 35%;
-  }
 
-  .header-links {
-    justify-content: space-evenly;
-    width: 100%;
-    margin-top: 2.5%;
-  }
-
-  .collection-head-links:nth-of-type(even) {
-    display: none;
-  }
-
-  .header-space:nth-of-type(even) {
-    display: none;
-  }
-
-  .header-space:nth-of-type(7) {
-    display: none;
-  }
 
   /* main home page */
-  .more-btn {
-    width: 50%;
-    border-radius: 2.5rem;
-    font-size: 1rem;
-  }
 
-  .more-btn:hover {
-    width: 65%;
-  }
 
   /* cards */
   .main-left-card {
-    width: 75vw;
-    margin-right: 0%;
     margin-bottom: 10%;
   }
 
   .main-right-card {
-    width: 75vw;
-    margin-left: 0%;
     margin-bottom: 10%;
   }
 
@@ -634,132 +674,16 @@
     font-size: 1.5rem;
   }
 
-  .card-description {
-    margin-bottom: 5%;
-    font-size: medium;
-  }
 
-  /* card hovers */
-  .card-title::after {
-    top: 25px;
-    height: 3px;
-  }
 
-  .beach:after {
-    width: 86px;
-  }
-
-  .clouds:after {
-    width: 103px;
-  }
-
-  .food:after {
-    width: 75px;
-  }
-
-  .nature:after {
-    width: 100px;
-  }
-
-  .night:after {
-    width: 145px;
-  }
-
-  .street:after {
-    width: 95px;
-  }
-
-  .sunrise:after {
-    width: 125px;
-  }
-
-  .sunset:after {
-    width: 115px;
-  }
-
-  /* GALLERY */
-  .container {
-    grid-template-areas:
-      "top top"
-      "middle middle"
-      "bottom bottom";
-  }
-
-  .collection1 {
-    grid-area: top;
-    grid-auto-rows: minmax(150px, auto);
-    grid-template-areas:
-      "top-left top-right"
-      "across across";
-    gap: 2px;
-  }
-
-  .collection2 {
-    grid-area: middle;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-auto-rows: minmax(150px, auto);
-
-    grid-template-areas:
-      "across across"
-      "bottom-left bottom-right";
-    gap: 2px;
-  }
-
-  .collection3 {
-    grid-area: bottom;
-    grid-auto-rows: minmax(100px, auto);
-    grid-template-columns: 1fr 1fr;
-    gap: 2px;
-  }
-
-  .collection3 img:nth-of-type(2) {
-    display: none;
-  }
 
 
   /* BLOGS */
-  .blog-card {
-    width: 80vw;
-    margin-bottom: 25%;
-  }
-
   .blog-links-container {
     margin-top: 10%;
   }
 
   .blog-link-btn {
-    font-size: 0.8rem;
-  }
-
-  /* FOOTER */
-  footer {
-    height: 25%;
-  }
-
-  .footer-social {
-    margin-bottom: 2.5%;
-  }
-
-  .footer-section {
-    width: 33%;
-  }
-
-
-
-  /* BLOGS */
-  .blog-card {
-    width: 80vw;
-    margin-bottom: 25%;
-  }
-
-  .blog-links-container {
-    margin-top: 10%;
-  }
-
-  .blog-link-btn {
-    height: 40px;
-    width: 20%;
     font-size: 1rem;
   }
 
@@ -792,11 +716,6 @@
 
 
 @media screen and (max-width: 360px) {
-
-  /* texts */
-
-
-
   /* Navbar */
 
 
@@ -822,11 +741,6 @@
 
 
   /* BLOGS */
-  .blog-card {
-    width: 80vw;
-    margin-bottom: 25%;
-  }
-
   .blog-links-container {
     margin-top: 10%;
   }

--- a/public/css/media.css
+++ b/public/css/media.css
@@ -433,7 +433,7 @@
 
   /* Navbar */
   .navbar-brand {
-    font-size: large;
+    font-size: x-large;
   }
 
   /* FOOTER */
@@ -570,9 +570,14 @@
 
 @media screen and (max-width: 414px) {
 
+  /* texts */
+  .main-h1 {
+    margin-top: 10%;
+  }
+
   /* Navbar */
   .navbar-brand {
-    font-size: medium;
+    font-size: large;
   }
 
   /* HOME */
@@ -580,14 +585,13 @@
   /* home head */
   .header-texts h1 {
     font-size: 70%;
+    margin-top: 35%;
   }
 
   .header-links {
-    flex-wrap: wrap;
     justify-content: space-evenly;
     width: 100%;
     margin-top: 2.5%;
-    /* margin: auto; */
   }
 
   .collection-head-links:nth-of-type(even) {
@@ -600,102 +604,6 @@
 
   .header-space:nth-of-type(7) {
     display: none;
-  }
-
-  /* main home page */
-  .more-btn {
-    width: 50%;
-    border-radius: 2.5rem;
-    font-size: 1rem;
-  }
-
-  .more-btn:hover {
-    width: 65%;
-  }
-
-  /* cards */
-  .main-left-card {
-    width: 75vw;
-    margin-right: 0%;
-    margin-bottom: 25%;
-  }
-
-  .main-right-card {
-    width: 75vw;
-    margin-left: 0%;
-    margin-bottom: 25%;
-  }
-
-  .card-title {
-    font-size: 2rem;
-  }
-
-  .card-description {
-    margin-bottom: 5%;
-  }
-
-  /* BLOGS */
-  .blog-card {
-    width: 80vw;
-    margin-bottom: 25%;
-  }
-
-  .blog-link-btn {
-    width: 20%;
-    font-size: 1rem;
-  }
-
-  /* FOOTER */
-  footer {
-    height: 25%;
-  }
-
-  .footer-social {
-    margin-bottom: 2.5%;
-  }
-
-  .footer-section {
-    width: 33%;
-  }
-
-  /* SERVICES */
-  .services-left-header {
-    position: relative;
-    left: 27.5%;
-    margin-top: 10%;
-    text-align: center;
-  }
-}
-
-@media screen and (max-width: 360px) {
-
-  /* texts */
-  .main-h1 {
-    margin-top: 10%;
-  }
-
-
-  /* Navbar */
-  .navbar-brand {
-    font-size: large;
-  }
-
-  /* sidebar */
-
-
-  /* HOME */
-
-  /* home head */
-  .header-texts h1 {
-    font-size: 70%;
-    margin-top: 35%;
-  }
-
-  .header-links {
-    flex-wrap: wrap;
-    justify-content: center;
-    width: 100%;
-    margin-top: 2.5%;
   }
 
   /* main home page */
@@ -769,8 +677,6 @@
     width: 115px;
   }
 
-
-
   /* GALLERY */
   .container {
     grid-template-areas:
@@ -810,7 +716,36 @@
   .collection3 img:nth-of-type(2) {
     display: none;
   }
-  
+
+
+  /* BLOGS */
+  .blog-card {
+    width: 80vw;
+    margin-bottom: 25%;
+  }
+
+  .blog-links-container {
+    margin-top: 10%;
+  }
+
+  .blog-link-btn {
+    font-size: 0.8rem;
+  }
+
+  /* FOOTER */
+  footer {
+    height: 25%;
+  }
+
+  .footer-social {
+    margin-bottom: 2.5%;
+  }
+
+  .footer-section {
+    width: 33%;
+  }
+
+
 
   /* BLOGS */
   .blog-card {
@@ -825,6 +760,78 @@
   .blog-link-btn {
     height: 40px;
     width: 20%;
+    font-size: 1rem;
+  }
+
+
+  /* FOOTER */
+  footer {
+    height: 25%;
+  }
+
+  .footer-social {
+    margin-bottom: 2.5%;
+  }
+
+  .footer-section {
+    width: 33%;
+  }
+
+
+  /* SERVICES */
+  .services-left-header {
+    position: relative;
+    left: 27.5%;
+    margin-top: 10%;
+    text-align: center;
+  }
+}
+
+
+
+
+
+@media screen and (max-width: 360px) {
+
+  /* texts */
+
+
+
+  /* Navbar */
+
+
+  /* sidebar */
+
+
+  /* HOME */
+
+  /* home head */
+
+
+  .header-links {
+    justify-content: center;
+  }
+
+  /* main home page */
+
+
+  /* cards */
+
+
+
+
+
+  /* BLOGS */
+  .blog-card {
+    width: 80vw;
+    margin-bottom: 25%;
+  }
+
+  .blog-links-container {
+    margin-top: 10%;
+  }
+
+  .blog-link-btn {
     font-size: 0.8rem;
   }
 

--- a/public/css/media.css
+++ b/public/css/media.css
@@ -96,6 +96,7 @@
   .services-left {
     background-position: 0px 0px, 69% 50%;
   }
+
   .services-left-header {
     right: 50%;
   }
@@ -139,19 +140,19 @@
     font-size: x-large;
   }
 
-    /* FOOTER */
-    footer {
-      height: 25%;
-    }
-  
-    .footer-social {
-      margin-bottom: 2.5%;
-      margin: auto;
-    }
-  
-    .footer-section {
-      width: 80%;
-    }
+  /* FOOTER */
+  footer {
+    height: 25%;
+  }
+
+  .footer-social {
+    margin-bottom: 2.5%;
+    margin: auto;
+  }
+
+  .footer-section {
+    width: 80%;
+  }
 
   /* HOME */
 
@@ -217,7 +218,7 @@
     width: 100%;
     height: 240px;
   }
-  
+
   .about-left-header {
     position: relative;
     left: 40%;
@@ -248,7 +249,7 @@
     font-size: small;
     line-height: 28px;
   }
-  
+
 
 
 
@@ -336,19 +337,19 @@
     font-size: x-large;
   }
 
-    /* FOOTER */
-    footer {
-      height: 25%;
-    }
-  
-    .footer-social {
-      margin-bottom: 2.5%;
-      margin: auto;
-    }
-  
-    .footer-section {
-      width: 80%;
-    }
+  /* FOOTER */
+  footer {
+    height: 25%;
+  }
+
+  .footer-social {
+    margin-bottom: 2.5%;
+    margin: auto;
+  }
+
+  .footer-section {
+    width: 80%;
+  }
 
   /* HOME */
 
@@ -413,23 +414,23 @@
   }
 
 
-    /* CONTACT */
-    .contact-left-header {
-      position: relative;
-      left: 33%;
-      margin-top: 10%;
-      text-align: center;
-    }
+  /* CONTACT */
+  .contact-left-header {
+    position: relative;
+    left: 33%;
+    margin-top: 10%;
+    text-align: center;
+  }
 
-    .contact-content {
-      padding-top: 0%;
-      padding-left: 10%;
-      padding-right: 5%;
-    }
+  .contact-content {
+    padding-top: 0%;
+    padding-left: 10%;
+    padding-right: 5%;
+  }
 }
 
 @media screen and (max-width: 576px) {
-  
+
   /* Navbar */
   .navbar-brand {
     font-size: large;
@@ -448,7 +449,7 @@
   .footer-section {
     width: 100%;
   }
-  
+
   /* HOME */
 
   /* home head */
@@ -553,16 +554,18 @@
     margin-top: 10%;
     text-align: center;
   }
+
   .services-icon {
     position: relative;
     width: 56px;
     height: 56px;
     padding: 16px;
   }
+
   .services-h2 {
     line-height: 20px;
     font-size: 16px;
-}
+  }
 }
 
 @media screen and (max-width: 414px) {
@@ -666,16 +669,26 @@
 
 @media screen and (max-width: 360px) {
 
+  /* texts */
+  .main-h1 {
+    margin-top: 10%;
+  }
+
+
   /* Navbar */
   .navbar-brand {
-    font-size: medium;
+    font-size: large;
   }
+
+  /* sidebar */
+
 
   /* HOME */
 
   /* home head */
   .header-texts h1 {
     font-size: 70%;
+    margin-top: 35%;
   }
 
   .header-links {
@@ -700,22 +713,104 @@
   .main-left-card {
     width: 75vw;
     margin-right: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 10%;
   }
 
   .main-right-card {
     width: 75vw;
     margin-left: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 10%;
   }
 
   .card-title {
-    font-size: 2rem;
+    font-size: 1.5rem;
   }
 
   .card-description {
     margin-bottom: 5%;
+    font-size: medium;
   }
+
+  /* card hovers */
+  .card-title::after {
+    top: 25px;
+    height: 3px;
+  }
+
+  .beach:after {
+    width: 86px;
+  }
+
+  .clouds:after {
+    width: 103px;
+  }
+
+  .food:after {
+    width: 75px;
+  }
+
+  .nature:after {
+    width: 100px;
+  }
+
+  .night:after {
+    width: 145px;
+  }
+
+  .street:after {
+    width: 95px;
+  }
+
+  .sunrise:after {
+    width: 125px;
+  }
+
+  .sunset:after {
+    width: 115px;
+  }
+
+
+
+  /* GALLERY */
+  .container {
+    grid-template-areas:
+      "top top"
+      "middle middle"
+      "bottom bottom";
+  }
+
+  .collection1 {
+    grid-area: top;
+    grid-auto-rows: minmax(150px, auto);
+    grid-template-areas:
+      "top-left top-right"
+      "across across";
+    gap: 2px;
+  }
+
+  .collection2 {
+    grid-area: middle;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: minmax(150px, auto);
+
+    grid-template-areas:
+      "across across"
+      "bottom-left bottom-right";
+    gap: 2px;
+  }
+
+  .collection3 {
+    grid-area: bottom;
+    grid-auto-rows: minmax(100px, auto);
+    grid-template-columns: 1fr 1fr;
+    gap: 2px;
+  }
+
+  .collection3 img:nth-of-type(2) {
+    display: none;
+  }
+  
 
   /* BLOGS */
   .blog-card {
@@ -723,9 +818,14 @@
     margin-bottom: 25%;
   }
 
+  .blog-links-container {
+    margin-top: 10%;
+  }
+
   .blog-link-btn {
+    height: 40px;
     width: 20%;
-    font-size: 1rem;
+    font-size: 0.8rem;
   }
 
   /* FOOTER */

--- a/public/css/media.css
+++ b/public/css/media.css
@@ -60,10 +60,6 @@
     font-size: 3rem;
   }
 
-  .card-description {
-    margin-bottom: 5%;
-  }
-
   /* BLOGS */
   .blog-card {
     width: 30vw;
@@ -107,6 +103,10 @@
   /* GENERAL HTML */
 
   /* texts */
+  .main-h1 {
+    margin-top: 5%;
+  }
+
   .left-h1 {
     position: relative;
     right: 0%;
@@ -159,6 +159,7 @@
   /* home head */
   .header-texts h1 {
     font-size: 90%;
+    margin-top: 35%;
   }
 
   /* main home page */
@@ -176,27 +177,61 @@
   .main-left-card {
     width: 66vw;
     margin-right: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .main-right-card {
     width: 66vw;
     margin-left: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .card-title {
     font-size: 3rem;
   }
 
-  .card-description {
-    margin-bottom: 5%;
-  }
+    /* card hovers */
+    .card-title::after {
+      top: 50px;
+      height: 5px;
+    }
+
+    .beach:after {
+      width: 170px;
+    }
+  
+    .clouds:after {
+      width: 205px;
+    }
+  
+    .food:after {
+      width: 145px;
+    }
+  
+    .nature:after {
+      width: 200px;
+    }
+  
+    .night:after {
+      width: 285px;
+    }
+  
+    .street:after {
+      width: 190px;
+    }
+  
+    .sunrise:after {
+      width: 245px;
+    }
+  
+    .sunset:after {
+      width: 225px;
+    }
 
   /* BLOGS */
   .blog-card {
     width: 66vw;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .blog-link-btn {
@@ -349,11 +384,6 @@
   /* HOME */
 
   /* home head */
-  .header-texts h1 {
-    font-size: 90%;
-    margin-top: 35%;
-  }
-
   .collection-head-links:nth-of-type(even) {
     display: none;
   }
@@ -367,74 +397,18 @@
   }
 
   /* main home page */
-  .more-btn {
-    width: 40%;
-    border-radius: 2.5rem;
-    font-size: 1.25rem;
-  }
 
-  .more-btn:hover {
-    width: 50%;
-  }
 
   /* cards */
   .main-left-card {
     width: 75vw;
-    margin-right: 0%;
-    margin-bottom: 5%;
   }
 
   .main-right-card {
     width: 75vw;
-    margin-left: 0%;
-    margin-bottom: 5%;
   }
 
-  .card-title {
-    font-size: 3rem;
-  }
 
-  .card-description {
-    font-size: medium;
-  }
-
-  /* card hovers */
-  .card-title::after {
-    top: 50px;
-    height: 5px;
-  }
-
-  .beach:after {
-    width: 170px;
-  }
-
-  .clouds:after {
-    width: 205px;
-  }
-
-  .food:after {
-    width: 145px;
-  }
-
-  .nature:after {
-    width: 200px;
-  }
-
-  .night:after {
-    width: 285px;
-  }
-
-  .street:after {
-    width: 190px;
-  }
-
-  .sunrise:after {
-    width: 245px;
-  }
-
-  .sunset:after {
-    width: 225px;
-  }
 
 
 
@@ -482,7 +456,6 @@
   /* BLOGS */
   .blog-card {
     width: 80vw;
-    margin-bottom: 5%;
   }
 
   .blog-link-btn {
@@ -611,7 +584,7 @@
 
 
 
-  
+
   /* CONTACT */
   .contact-left-header {
     position: relative;

--- a/public/css/media.css
+++ b/public/css/media.css
@@ -1,22 +1,73 @@
 /* Max-Width */
 @media screen and (max-width: 1115px) {
 
+  /* Home */
+
+  /* main home page */
+  .more-btn {
+    width: 30%;
+    border-radius: 2.5rem;
+    font-size: 1.25rem;
+  }
+
+  .more-btn:hover {
+    width: 35%;
+  }
+
   /* cards */
   .main-left-card {
     width: 40vw;
     margin-right: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .main-right-card {
     width: 40vw;
     margin-left: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .card-title {
-    font-size: 3.5rem;
+    font-size: 3rem;
   }
+
+    /* card hovers */
+    .card-title::after {
+      top: 50px;
+      height: 5px;
+    }
+  
+    .beach:after {
+      width: 170px;
+    }
+  
+    .clouds:after {
+      width: 205px;
+    }
+  
+    .food:after {
+      width: 145px;
+    }
+  
+    .nature:after {
+      width: 200px;
+    }
+  
+    .night:after {
+      width: 285px;
+    }
+  
+    .street:after {
+      width: 190px;
+    }
+  
+    .sunrise:after {
+      width: 245px;
+    }
+  
+    .sunset:after {
+      width: 225px;
+    }
 }
 
 @media screen and (max-width: 992px) {
@@ -26,12 +77,7 @@
   /* sidebar */
 
 
-  /* HOME */
 
-  /* home head */
-  .header-links {
-    width: 100%;
-  }
 
   /* main home page */
   .more-btn {
@@ -47,57 +93,13 @@
   /* cards */
   .main-left-card {
     width: 45vw;
-    margin-right: 0%;
-    margin-bottom: 5%;
   }
 
   .main-right-card {
     width: 45vw;
-    margin-left: 0%;
-    margin-bottom: 5%;
   }
 
-  .card-title {
-    font-size: 3rem;
-  }
 
-  /* card hovers */
-  .card-title::after {
-    top: 50px;
-    height: 5px;
-  }
-
-  .beach:after {
-    width: 170px;
-  }
-
-  .clouds:after {
-    width: 205px;
-  }
-
-  .food:after {
-    width: 145px;
-  }
-
-  .nature:after {
-    width: 200px;
-  }
-
-  .night:after {
-    width: 285px;
-  }
-
-  .street:after {
-    width: 190px;
-  }
-
-  .sunrise:after {
-    width: 245px;
-  }
-
-  .sunset:after {
-    width: 225px;
-  }
 
 
   /* BLOGS */

--- a/public/css/media.css
+++ b/public/css/media.css
@@ -72,12 +72,7 @@
 
 @media screen and (max-width: 992px) {
 
-  /* Navbar */
-
-  /* sidebar */
-
-
-
+  /* Home */
 
   /* main home page */
   .more-btn {
@@ -671,6 +666,11 @@
 
   .card-title {
     font-size: 1.5rem;
+  }
+
+  /* card hovers */
+  .card-title::after {
+    top: 30px;
   }
 
 

--- a/public/css/media.css
+++ b/public/css/media.css
@@ -332,30 +332,26 @@
 
 @media screen and (max-width: 676px) {
 
+  /* texts */
+  .main-h1 {
+    margin-top: 10%;
+  }
+
   /* Navbar */
   .navbar-brand {
     font-size: x-large;
   }
 
-  /* FOOTER */
-  footer {
-    height: 25%;
-  }
 
-  .footer-social {
-    margin-bottom: 2.5%;
-    margin: auto;
-  }
 
-  .footer-section {
-    width: 80%;
-  }
+
 
   /* HOME */
 
   /* home head */
   .header-texts h1 {
     font-size: 90%;
+    margin-top: 35%;
   }
 
   .collection-head-links:nth-of-type(even) {
@@ -385,13 +381,13 @@
   .main-left-card {
     width: 75vw;
     margin-right: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .main-right-card {
     width: 75vw;
     margin-left: 0%;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .card-title {
@@ -399,18 +395,101 @@
   }
 
   .card-description {
-    margin-bottom: 5%;
+    font-size: medium;
+  }
+
+  /* card hovers */
+  .card-title::after {
+    top: 50px;
+    height: 5px;
+  }
+
+  .beach:after {
+    width: 170px;
+  }
+
+  .clouds:after {
+    width: 205px;
+  }
+
+  .food:after {
+    width: 145px;
+  }
+
+  .nature:after {
+    width: 200px;
+  }
+
+  .night:after {
+    width: 285px;
+  }
+
+  .street:after {
+    width: 190px;
+  }
+
+  .sunrise:after {
+    width: 245px;
+  }
+
+  .sunset:after {
+    width: 225px;
+  }
+
+
+
+
+  /* GALLERY */
+  .container {
+    grid-template-areas:
+      "top top"
+      "middle middle"
+      "bottom bottom";
+  }
+
+  .collection1 {
+    grid-area: top;
+    grid-auto-rows: minmax(150px, auto);
+    grid-template-areas:
+      "top-left top-right"
+      "across across";
+    gap: 3px;
+  }
+
+  .collection2 {
+    grid-area: middle;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: minmax(150px, auto);
+
+    grid-template-areas:
+      "across across"
+      "bottom-left bottom-right";
+    gap: 3px;
+  }
+
+  .collection3 {
+    grid-area: bottom;
+    grid-auto-rows: minmax(100px, auto);
+    grid-template-columns: 1fr 1fr;
+    gap: 3px;
+  }
+
+  .collection3 img:nth-of-type(2) {
+    display: none;
   }
 
   /* BLOGS */
   .blog-card {
     width: 80vw;
-    margin-bottom: 25%;
+    margin-bottom: 5%;
   }
 
   .blog-link-btn {
+    margin-top: 5%;
     width: 20%;
-    font-size: 1.25rem;
+    height: 40px;
+    font-size: 1rem;
   }
 
 
@@ -427,19 +506,26 @@
     padding-left: 10%;
     padding-right: 5%;
   }
+
+  /* FOOTER */
+  footer {
+    height: 25%;
+  }
+
+  .footer-social {
+    margin-bottom: 2.5%;
+    margin: auto;
+  }
+
+  .footer-section {
+    width: 80%;
+  }
 }
 
 @media screen and (max-width: 576px) {
 
-  /* texts */
-  .main-h1 {
-    margin-top: 10%;
-  }
-
   /* Navbar */
-  .navbar-brand {
-    font-size: x-large;
-  }
+
 
 
 
@@ -448,7 +534,6 @@
   /* home head */
   .header-texts h1 {
     font-size: 70%;
-    margin-top: 35%;
   }
 
   .header-links {
@@ -459,7 +544,6 @@
   /* main home page */
   .more-btn {
     width: 50%;
-    border-radius: 2.5rem;
     font-size: 1rem;
   }
 
@@ -468,24 +552,8 @@
   }
 
   /* cards */
-  .main-left-card {
-    width: 75vw;
-    margin-right: 0%;
-    margin-bottom: 5%;
-  }
-
-  .main-right-card {
-    width: 75vw;
-    margin-left: 0%;
-    margin-bottom: 5%;
-  }
-
   .card-title {
     font-size: 2rem;
-  }
-
-  .card-description {
-    font-size: medium;
   }
 
   /* card hovers */
@@ -527,59 +595,23 @@
   }
 
 
-    /* GALLERY */
-    .container {
-      grid-template-areas:
-        "top top"
-        "middle middle"
-        "bottom bottom";
-    }
-  
-    .collection1 {
-      grid-area: top;
-      grid-auto-rows: minmax(150px, auto);
-      grid-template-areas:
-        "top-left top-right"
-        "across across";
-      gap: 2px;
-    }
-  
-    .collection2 {
-      grid-area: middle;
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-auto-rows: minmax(150px, auto);
-  
-      grid-template-areas:
-        "across across"
-        "bottom-left bottom-right";
-      gap: 2px;
-    }
-  
-    .collection3 {
-      grid-area: bottom;
-      grid-auto-rows: minmax(100px, auto);
-      grid-template-columns: 1fr 1fr;
-      gap: 2px;
-    }
-  
-    .collection3 img:nth-of-type(2) {
-      display: none;
-    }
-
-  /* BLOGS */
-  .blog-card {
-    width: 80vw;
-    margin-bottom: 25%;
+  /* GALLERY */
+  .collection1 {
+    gap: 2px;
   }
 
-  .blog-link-btn {
-    margin-top: 5%;
-    width: 20%;
-    height: 40px;
-    font-size: 1rem;
+  .collection2 {
+    gap: 2px;
   }
 
+  .collection3 {
+    gap: 2px;
+  }
+
+
+
+
+  
   /* CONTACT */
   .contact-left-header {
     position: relative;
@@ -679,6 +711,10 @@
 
 
   /* BLOGS */
+  .blog-card {
+    margin-bottom: 10%;
+  }
+  
   .blog-links-container {
     margin-top: 10%;
   }

--- a/public/css/navbar.css
+++ b/public/css/navbar.css
@@ -10,26 +10,11 @@
     width: 25%;
     z-index: 100;
     height: 100%;
-    background: #fdfdfd;
+    background: #fdfdfde5;
     transition: all .5s ease;
-    /* border-right: black solid 1px; */
-    /* overflow: scroll; */
-}
-header {
-    margin-top: 7.5%;
-    text-decoration-color: black;
-    font-family: 'Allura', cursive;
 }
 .sidebar-ul {
     margin-top: 25%;
-}
-.sidebar header {
-    text-align: center;
-    line-height: 70px;
-    font-size: 150%;
-    color: black;
-    background: #fdfdfd;
-    user-select: none;
 }
 .sidebar ul a {
     display: block;
@@ -59,7 +44,7 @@ ul li:hover a {
 label #btn, label #cancel {
     position: absolute;
     cursor: pointer;
-    background: #fdfdfd;
+    background: #fff;
     border-radius: 3px;
 }
 label #btn {
@@ -121,4 +106,42 @@ nav {
     opacity: 1;
     color: #fff;
     font-family: 'Allura', cursive;
+}
+
+
+/* Media Queries */
+
+@media screen and (max-width: 992px) {
+    .sidebar {
+        right: -25%;
+        width: 25%;
+      }
+}
+
+@media screen and (max-width: 767px) {
+    .sidebar {
+        right: -35%;
+        width: 35%;
+      }
+}
+
+@media screen and (max-width: 676px) {
+    .sidebar {
+        right: -40%;
+        width: 40%;
+      }
+}
+
+@media screen and (max-width: 576px) {
+    .sidebar {
+        right: -50%;
+        width: 50%;
+      }
+}
+
+@media screen and (max-width: 414px) {
+    .sidebar {
+        right: -60%;
+        width: 60%;
+      }
 }


### PR DESCRIPTION
I made some adjustments to all the pages so that they maintain the same appearance at various break points (360px, 414px, 576px, 676px, 767px, 992px and 1115px) on the media.css and on the app.css I made some adjustments to accommodate the various screen sizes.
The navbar.css file, I made the adjustments for the various break points due to having a hard time implementing the media queries on the media.css file.

I made changes to the home page by adjusting the card titles and their underlines when the user hovers above the card by adjusting the `top` property and the height of the content and then adjusting the width of the content according to the width of the title it is under.
The h1's that are nested under `header-texts` got adjusted for with the `margin-top` and the `font-size`.
I adjusted the `.more-btn` and its width and font size when hovered above.
I also adjusted the gallery page and its image layout by doing the following:

- Changing the `grid-template-areas` layout for the `.container` and all the `.collections` divs.
- Adding grid-auto-rows to the all the `.collections` divs.
- I changed the value of the `gap` property

I made changes to the `.blog-link-btn` by adjusting the margin-top, height of the links and the font-size so that the text does not overflow the link and is centered vertically inside the anchor tag and to make sure it is not too close to the `.header-intro`.

I also removed any of the redundant computations from breakpoints which would still have access to the same computations if they were to get moved to a break point where it makes sense to have it there, such as the `.collection-head-links` which were removed from the 414px and 576px break points.

The approach that I took for working on the break points was to work from the bottom up, hence why I would add something to a break point and then remove it as I start working on the next break point.