### PR TITLE
This fixes #13

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -407,18 +407,18 @@ footer {
 .more-btn {
     width: 17.5%;
     height: 3rem;
+    padding-top: 10px;
     border: 0;
     transition: ease .2s;
     background: #fc3355;
     border-radius: 2.5rem;
+    text-align: center;
     font-size: 1.25rem;
     color: #fff;
+    box-sizing: border-box;
 }
 .more-btn:hover {
     width: 20%;
-}
-.more-link {
-    color: #fff;
 }
 
 

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -110,11 +110,9 @@
 
 
     <div class="more-div">
-        <button class="more-btn">
-            <a href="/collections" class="more-link">
+            <a href="/collections" class="more-btn">
                 Show More Collections
             </a>
-        </button>
     </div>
 
 
@@ -187,9 +185,7 @@
     </section>
 
     <div class="more-div">
-        <button class="more-btn">
-            <a href="/blogs" class="more-link">
+            <a href="/blogs" class="more-btn">
                 Show More Posts
             </a>
-        </button>
     </div>


### PR DESCRIPTION
I removed the button element which wraps around the anchor tag and also removed the `.more-link` class from the anchor tag before moving the `.more-btn` class into the anchor tag.

This will allow the user to hover over any part of `.more-btn` and still have access to the link.